### PR TITLE
Allow using only the endpoint URL supplied by AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To use this in GitHub Actions you can add this snippet to your workflow job step
 
 ```yaml
 - name: Get Bastion role creds
-  uses: idealo/setup-iam-bastion-credentials-action@v0
+  uses: idealo/setup-iam-bastion-credentials-action@v0.1
   with:
     endpoint: <ENDPOINT-FROM-STACK-OUTPUT>
 - name: Assume PoC deployment role
@@ -58,7 +58,7 @@ However, credentials retrieved via this process can only be valid for a maximum 
 
 ```yaml
 - name: Get Bastion role creds
-  uses: idealo/setup-iam-bastion-credentials-action@v0
+  uses: idealo/setup-iam-bastion-credentials-action@v0.1
   with:
     endpoint: <ENDPOINT-FROM-STACK-OUTPUT>
 - name: Assume PoC deployment role
@@ -85,7 +85,7 @@ In order to have access for creating credentials, each action that may access AW
 
 ```yaml
 - name: Get Bastion role creds
-  uses: idealo/setup-iam-bastion-credentials-action@v0
+  uses: idealo/setup-iam-bastion-credentials-action@v0.1
   with:
     endpoint: <ENDPOINT-FROM-STACK-OUTPUT>
     mode: config

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,11 +52,10 @@ credential_process = ${process.execPath} ${scriptPath} ${endpoint}`.trim()
 async function run(): Promise<void> {
   try {
     // Ensure that the Endpoint always contains the creds path
-    const endpoint_input = core.getInput('endpoint', {required: true})
-    if (endpoint_input.endsWith('/creds/')) {
-      var endpoint = endpoint_input
-    } else {
-      var endpoint = "${endpoint_input}/creds/"
+    let endpoint = core.getInput('endpoint', {required: true})
+
+    if (! endpoint.endsWith('/creds/')) {
+      endpoint = "${endpoint}/creds/"
     }
 
     switch (core.getInput('mode')) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,7 +53,7 @@ async function run(): Promise<void> {
   try {
     // Ensure that the Endpoint always contains the creds path
     const endpoint_input = core.getInput('endpoint', {required: true})
-    if (endpoint_input.endswith.endswith('/creds/')) {
+    if (endpoint_input.endsWith('/creds/')) {
       var endpoint = endpoint_input
     } else {
       var endpoint = "${endpoint_input}/creds/"

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,7 +51,13 @@ credential_process = ${process.execPath} ${scriptPath} ${endpoint}`.trim()
 
 async function run(): Promise<void> {
   try {
-    const endpoint = core.getInput('endpoint', {required: true})
+    // Ensure that the Endpoint always contains the creds path
+    const endpoint_input = core.getInput('endpoint', {required: true})
+    if (endpoint_input.endswith.endswith('/creds/')) {
+      var endpoint = endpoint_input
+    } else {
+      var endpoint = "${endpoint_input}/creds/"
+    }
 
     switch (core.getInput('mode')) {
       case 'env':


### PR DESCRIPTION
The AWS endpoint supplied/stated by AWS Lambda will not append "/creds/".
This change allows to use only the supplied URL.